### PR TITLE
Add title ID when fetching trophy summary from title

### DIFF
--- a/src/psnawp_api/models/trophies/trophy_titles.py
+++ b/src/psnawp_api/models/trophies/trophy_titles.py
@@ -49,6 +49,8 @@ class TrophyTitle:
     last_updated_date_time: Optional[datetime] = field(converter=iso_format_to_datetime)
     "Date most recent trophy earned for the title (UTC+00:00 TimeZone)"
     # when title_id is passed
+    np_title_id: Optional[str]
+    "Title ID of the title if passed"
     rarest_trophies: list[Trophy] = field(factory=list, hash=False)
     "Returns the trophy where earned is true with the lowest trophyEarnedRate"
 
@@ -94,6 +96,7 @@ class TrophyTitles:
             ).json()
 
             per_page_items = 0
+            np_title_id: Optional[str]
             trophy_titles: list[dict[Any, Any]] = response.get("trophyTitles")
             for trophy_title in trophy_titles:
                 title_trophy_sum = TrophyTitle(
@@ -126,6 +129,7 @@ class TrophyTitles:
                             {"bronze": 0, "silver": 0, "gold": 0, "platinum": 0},
                         )
                     ),
+                    np_title_id=None,
                     rarest_trophies=Trophy.from_trophies_list(trophy_title.get("rarestTrophies")),
                 )
                 yield title_trophy_sum
@@ -190,6 +194,7 @@ class TrophyTitles:
                         "earnedTrophies",
                         {"bronze": 0, "silver": 0, "gold": 0, "platinum": 0},
                     ),
+                    np_title_id=title.get("npTitleId"),
                     rarest_trophies=Trophy.from_trophies_list(trophy_title.get("rarestTrophies")),
                 )
                 yield title_trophy_sum

--- a/tests/unit_tests/test_user.py
+++ b/tests/unit_tests/test_user.py
@@ -167,12 +167,15 @@ def test_user__trophy_titles_for_title(psnawp_fixture):
             if trophy_title.title_name == "Fallout 76":
                 assert trophy_title.np_communication_id == "NPWR15509_00"
                 assert trophy_title.np_service_name == "trophy"
+                assert trophy_title.np_title_id == "PPSA01506_00"
             elif trophy_title.title_name == "Immortals Fenyx Rising ™":
                 assert trophy_title.np_communication_id == "NPWR21237_00"
                 assert trophy_title.np_service_name == "trophy2"
+                assert trophy_title.np_title_id == "CUSA12057_00"
             elif trophy_title.title_name == "Grand Theft Auto V":
                 assert trophy_title.np_communication_id == "NPWR06221_00"
                 assert trophy_title.np_service_name == "trophy"
+                assert trophy_title.np_title_id == "CUSA00419_00"
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
- Added `np_title_id` along with trophy data when pulling trophy titles via title ID
- This will be helpful to easily form a link between `trophy titles` and `title stats` instead of having to call `game_title()` to form that link