### PR TITLE
Fixed search method name for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ print(group.leave_group())
 new_group = psnawp.group(users_list=[example_user_1, example_user_2])
 
 search = psnawp.search()
-print(search.get_title_details(title_id="PPSA03420_00"))
+print(search.get_title_id(title_name="GTA 5"))
 print(search.universal_search("GTA 5"))
 
 # Get Play Times (PS4, PS5 above only)


### PR DESCRIPTION
Hello! I followed the quick example (copy/paste) in the README and got the following error:

![image](https://github.com/isFakeAccount/psnawp/assets/83784102/481e2447-bbfa-483e-8849-f1936a83dec5)

I looked into the source code/docs and you unintentionally used the wrong method here.
It should be 
``` print(search.get_title_id(title_name="GTA 5")) ```
Instead of 
``` print(search.get_title_details(title_id="PPSA03420_00")) ```
as I couldn't find any method called get_title_details  in the source code