### PR TITLE
Correct codeblock example

### DIFF
--- a/src/psnawp_api/models/client.py
+++ b/src/psnawp_api/models/client.py
@@ -279,7 +279,7 @@ class Client:
         .. code-block:: Python
 
             client = psnawp.me()
-            for trophy_title in client.trophy_titles_for_title(title_id='CUSA00265_00'):
+            for trophy_title in client.trophy_titles_for_title(title_ids=['CUSA00265_00']):
                 print(trophy_title)
 
         """

--- a/src/psnawp_api/models/user.py
+++ b/src/psnawp_api/models/user.py
@@ -243,7 +243,7 @@ class User:
         .. code-block:: Python
 
             user_example = psnawp.user(online_id="VaultTec_Trading")
-            for trophy_title in user_example.trophy_titles_for_title(title_id='CUSA00265_00'):
+            for trophy_title in user_example.trophy_titles_for_title(title_ids=['CUSA00265_00']):
                 print(trophy_title)
 
         """


### PR DESCRIPTION
Correct codeblock example to contain the correct keyword argument (from title_id to title_ids) and the type of the passed variable (from string, to list containing 1 string).