### PR TITLE
Bugfix: incorrect play time parsing

### DIFF
--- a/src/psnawp_api/utils/misc.py
+++ b/src/psnawp_api/utils/misc.py
@@ -53,23 +53,20 @@ def play_duration_to_timedelta(play_duration: Optional[str]) -> timedelta:
     minutes = 0
     seconds = 0
 
-    if play_duration is not None:
-        # Strip everything and split into list of numbers separated by alphabets
-        digits_list = [int(s) for s in re.findall(r"\d+", play_duration)]
-        length = len(digits_list)
+    if play_duration:
+        # Regex pattern to match hours, minutes, and seconds
+        # Valid patters: PT243H18M48S, PT21M18S, PT18H, PT18H20S, PT4H21M
+        pattern = r'PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?'
 
-        # Example: PT243H18M48S = 243 hours, 18 minutes, 48 seconds
-        if length == 3:
-            hours = digits_list[0]
-            minutes = digits_list[1]
-            seconds = digits_list[2]
-        # Example: PT21M18S = 21 minutes, 18 seconds
-        elif length == 2:
-            minutes = digits_list[0]
-            seconds = digits_list[1]
-        # Example: PT39S = 39 seconds
-        elif length == 1:
-            seconds = digits_list[0]
+        # Search for patterns in the input string
+        match = re.search(pattern, play_duration)
+        if not match:
+            return timedelta(hours=hours, minutes=minutes, seconds=seconds)
+
+        # Extract hours, minutes, and seconds, or default to 0 if not present
+        hours = int(match.group(1)) if match.group(1) else 0
+        minutes = int(match.group(2)) if match.group(2) else 0
+        seconds = int(match.group(3)) if match.group(3) else 0
 
     # If for some reason the string is malformed or None, timedelta will return 0
     return timedelta(hours=hours, minutes=minutes, seconds=seconds)

--- a/tests/unit_tests/test_utils_misc.py
+++ b/tests/unit_tests/test_utils_misc.py
@@ -5,6 +5,8 @@ from datetime import timedelta
 def test_play_duration_to_timedelta_valid_inputs():
     hh_mm_ss_raw = "PT90H23M22S"
     assert play_duration_to_timedelta(hh_mm_ss_raw) == timedelta(hours=90, minutes=23, seconds=22)
+    hh_ss_raw = "PT18H22S"
+    assert play_duration_to_timedelta(hh_ss_raw) == timedelta(hours=18, seconds=22)
     mm_ss_raw = "PT22M38S"
     assert play_duration_to_timedelta(mm_ss_raw) == timedelta(minutes=22, seconds=38)
     ss_raw = "PT38S"


### PR DESCRIPTION
### Bugfix: Incorrect play time parsing
- Previous implementation didn't account for a scenario where there were only `Hours` and `Seconds` in the input string which led this input: `PT18H20S` to be parsed as `18 minutes 20 seconds`.
- `PT18H20S` is a valid response coming from the PSN API.

This function now produces the following time delta based on the provided inputs:
<img width="341" alt="Screenshot 2024-01-21 at 6 29 52 pm" src="https://github.com/isFakeAccount/psnawp/assets/7836579/6aaa9660-711b-472b-bb60-6551fade5438">
