### PR TITLE
Bugfix: Add PSPC platform type

### DIFF
--- a/src/psnawp_api/models/trophies/trophy_constants.py
+++ b/src/psnawp_api/models/trophies/trophy_constants.py
@@ -18,6 +18,7 @@ class PlatformType(Enum):
     PS3 = "PS3"
     PS4 = "PS4"
     PS5 = "PS5"
+    PSPC = "PSPC"
 
 
 class TrophyRarity(Enum):


### PR DESCRIPTION
Library crashing for trophy titles after new platform type added by PSN API. This pull request fixes the bug for the time being, but maybe the library should have a fallback such that it falls back to `UNKNOWN` instead of crashing in case a new platform is added in the future.

<img width="634" alt="Screenshot 2024-05-10 at 8 15 05 PM" src="https://github.com/isFakeAccount/psnawp/assets/7836579/d56c7f49-daf0-46cf-b345-221ec8da30b7">
