### PR TITLE
fix(docs): correct friends_list docstring example in the User model

### DIFF
--- a/src/psnawp_api/models/user.py
+++ b/src/psnawp_api/models/user.py
@@ -183,8 +183,8 @@ class User:
 
         .. code-block:: Python
 
-            client = psnawp.me()
-            friends_list = client.friends_list()
+            user_example = psnawp.user(online_id="VaultTec_Trading")
+            friends_list = user_example.friends_list()
 
             for friend in friends_list:
                 ...


### PR DESCRIPTION
Hello! Just a quick correction for a simple error: the friends_list method example in the docstring referred to the Client model instead of the User model.