### PR TITLE
Set `max_delay` to match the rate limiter interval instead of hardcoding

### DIFF
--- a/src/psnawp_api/core/request_builder.py
+++ b/src/psnawp_api/core/request_builder.py
@@ -6,7 +6,7 @@ from http import HTTPStatus
 from logging import getLogger
 from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict, cast
 
-from pyrate_limiter import Duration, Limiter, LimiterDelayException
+from pyrate_limiter import Limiter, LimiterDelayException
 from pyrate_limiter.buckets.sqlite_bucket import SQLiteBucket
 from requests import Session
 from typing_extensions import NotRequired, Unpack
@@ -137,7 +137,7 @@ class RequestBuilder:
         db_path = get_temp_db_path()
 
         sqlite_bucket = SQLiteBucket.init_from_file(psn_api_rates, db_path=str(db_path))
-        self.limiter = Limiter(sqlite_bucket, raise_when_fail=False, max_delay=Duration.SECOND * 3)
+        self.limiter = Limiter(sqlite_bucket, raise_when_fail=False, max_delay=rate_limit.interval)
 
         self.session = Session()
         self.session.headers.update(self.common_headers)


### PR DESCRIPTION
In the Home Assistant integration we set the rate limit to 300/15min but the max delay is hardcoded to 3seconds. The result is that pyrate_limiter is spamming the logs when requests have to be delayed.

```
Required delay too large: actual=11393, expected=3000
Required delay too large: actual=10920, expected=3000
Required delay too large: actual=14716, expected=3000
Required delay too large: actual=14684, expected=3000
Required delay too large: actual=13249, expected=3000
```